### PR TITLE
Adding optional text wrapping support

### DIFF
--- a/reframework/autorun/ModOptionsMenu/ModMenuApi.lua
+++ b/reframework/autorun/ModOptionsMenu/ModMenuApi.lua
@@ -347,6 +347,7 @@ function ModUI.Options(label, curValue, optionNames, optionMessages, toolTip, im
 	
 	if optionNames ~= opt.enumNames or optionMessages ~= opt.originalEnumMessages then
 		opt.enumNames = optionNames;
+		opt.originalEnumMessages = optionMessages;
 		opt.enumMessages = WrapTextTable(optionMessages);
 		opt.needsUpdate = true;
 	end

--- a/reframework/autorun/ModOptionsMenu/ModMenuApi.lua
+++ b/reframework/autorun/ModOptionsMenu/ModMenuApi.lua
@@ -125,6 +125,7 @@ local function CheckLabel(opt, toolTip)
 
 	if (opt.message ~= toolTip) then
 		opt.message = toolTip;
+		opt.displayMessage = WrapText(toolTip);
 		opt.needsUpdate = true;
 	end
 end
@@ -154,8 +155,6 @@ local function GetOptionData(mod, optType, label, toolTip, defaultValue, immedia
 	if not data then
 	
 		if not defaultValue then defaultValue = 0; end
-
-		toolTip = WrapText(toolTip);
 		
 		data = {
 			parentMod = mod;
@@ -166,7 +165,7 @@ local function GetOptionData(mod, optType, label, toolTip, defaultValue, immedia
 			name = label;
 			displayName = (optType == HEADER) and label or GetFormattedName(label);
 			message = toolTip;
-			displayMessage = toolTip;
+			displayMessage = WrapText(toolTip);
 			min = 0;
 			max = 0;
 			enumCount = 1;


### PR DESCRIPTION
Text wrapping will occur if the string is bigger than the maximum length (basically, before the text starts resizing too much) and only if the input string has no newlines. If it has, we'll assume the mod author wants to format it themselves, and leave it as is.

So this change won't affect anyone already using newlines in their tooltips, but will allow them to opt in.

Implements #7.